### PR TITLE
Update Incentives Dashboard - Round 24 Feb 15th

### DIFF
--- a/distros.yml
+++ b/distros.yml
@@ -30,17 +30,17 @@ rounds:
         optional:
           Pool size: ${{UNI_V2_ETH_RAI_POOL_SIZE}}
 
-      - until: Ongoing
-        amount: 87.5 FLX/day
-        name: FLX/ETH Uniswap v2 stakers
-        image: https://app.reflexer.finance/static/media/stFLX.f0676c46.svg
-        description: Uniswap v2 FLX/ETH LP stakers. More <a href="https://docs.reflexer.finance/incentives/flx-staking" target="_blank">here</a>
-        link: https://app.reflexer.finance/#/earn/staking
-        apy: "{{FLX_STAKING_APR}}%"
-        apy_title: "FLX APR"
-        apy_description: "FLX APR only, does not include fee revenue and potential impermanent loss."
-        optional:
-          Pool size: ${{FLX_STAKING_POOL_SIZE}}
+      # - until: Ongoing
+      #   amount: 87.5 FLX/day
+      #   name: FLX/ETH Uniswap v2 stakers
+      #   image: https://app.reflexer.finance/static/media/stFLX.f0676c46.svg
+      #   description: Uniswap v2 FLX/ETH LP stakers. More <a href="https://docs.reflexer.finance/incentives/flx-staking" target="_blank">here</a>
+      #   link: https://app.reflexer.finance/#/earn/staking
+      #   apy: "{{FLX_STAKING_APR}}%"
+      #   apy_title: "FLX APR"
+      #   apy_description: "FLX APR only, does not include fee revenue and potential impermanent loss."
+      #   optional:
+      #     Pool size: ${{FLX_STAKING_POOL_SIZE}}
 
       # - until: Ongoing
       #   amount: 20 FLX/day

--- a/distros.yml
+++ b/distros.yml
@@ -1,11 +1,11 @@
 rounds:
-  - number: 5
+  - number: 24
     name: Current RAI Incentives
-    snapshotDate: 2021-11-15T12:50Z
+    snapshotDate: 2023-04-15T12:50Z
     # distributionDate: 2021-11-17T12:50Z
     distros:
       - until: Ongoing
-        amount: 40 FLX/day
+        amount: 10 FLX/day
         name: Uniswap V3 RAI/DAI LP + Minter
         image: https://images.ctfassets.net/zql9qw49kkiw/gODeJOOfrFIXz5pGXkNVO/df191e8900a2e9c9c868344b874c09ea/uniswap.svg
         description: Mint RAI and LP on at least 5 ticks at redemption price and market price in the 0.05% Uniswap v3 RAI/DAI Pool. More <a href="https://docs.reflexer.finance/incentives/rai-uniswap-v3-mint-+-lp-incentives-program" target="_blank">here</a>
@@ -19,7 +19,7 @@ rounds:
           Recommended range: "{{UNISWAP_V3_RECOMMENDED}}"
 
       - until: Ongoing
-        amount: 20 FLX/day
+        amount: 30 FLX/day
         name: Uniswap V2 RAI/ETH LP
         image: https://images.ctfassets.net/zql9qw49kkiw/gODeJOOfrFIXz5pGXkNVO/df191e8900a2e9c9c868344b874c09ea/uniswap.svg
         description: LP in the Uniswap v2 RAI/ETH Pool. More <a href="https://docs.reflexer.finance/incentives/rai-mint-+-lp-incentives-program" target="_blank">here</a>
@@ -42,12 +42,12 @@ rounds:
         optional:
           Pool size: ${{FLX_STAKING_POOL_SIZE}}
 
-      - until: Ongoing
-        amount: 20 FLX/day
-        name: Curve Finance
-        image: https://images.ctfassets.net/zql9qw49kkiw/2Blf7JTMfHaPK5RBGrTxl1/e2a59ed15d33012d1f7ca897129eef04/curve-logo.png?h=250
-        description: RAI LPs on curve, direct holders of the RAI-3CRV LP token only (Convex unsupported).
-        link: https://curve.fi/rai/deposit
+      # - until: Ongoing
+      #   amount: 20 FLX/day
+      #   name: Curve Finance
+      #   image: https://images.ctfassets.net/zql9qw49kkiw/2Blf7JTMfHaPK5RBGrTxl1/e2a59ed15d33012d1f7ca897129eef04/curve-logo.png?h=250
+      #   description: RAI LPs on curve, direct holders of the RAI-3CRV LP token only (Convex unsupported).
+      #   link: https://curve.fi/rai/deposit
 
       - until: Ongoing
         amount: Variable CRV & CVX rewards

--- a/src/job.ts
+++ b/src/job.ts
@@ -128,7 +128,7 @@ export const createDoc = async (): Promise<Document> => {
   const raiInUniV2RaiEth = bigNumberToNumber(multiCallData[0]._reserve0) / 1e18;
   valuesMap.set(
     "UNI_V2_ETH_RAI_APR",
-    formatPercent(((20 * 365 * flxPrice) / (raiInUniV2RaiEth * 2 * raiPrice)) * 100)
+    formatPercent(((30 * 365 * flxPrice) / (raiInUniV2RaiEth * 2 * raiPrice)) * 100)
   );
 
   // Uniswap -- ETH/RAI pool size
@@ -247,7 +247,7 @@ export const createDoc = async (): Promise<Document> => {
 
   const tickRangeToAPR = (arr: number[]) => {
     const liquidity = 1e18 / (1.0001 ** (arr[1] / 2) - 1.0001 ** (arr[0] / 2));
-    return (((liquidity / totalLiquidity) * 40 * 365 * flxPrice) / 2.5) * 100;
+    return (((liquidity / totalLiquidity) * 10 * 365 * flxPrice) / 2.5) * 100;
   };
 
   valuesMap.set(


### PR DESCRIPTION
- Uniswap V3 RAI/DAI LP + Minter: 40 -> 10
- Uniswap V2 RAI/ETH LP: 20 -> 30
- Curve Finance:  20 -> 0 (removed)